### PR TITLE
Change private key that compathelper uses to COMPATHELPER_PRIV

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -13,5 +13,5 @@ jobs:
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
         run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+          ssh: ${{ secrets.COMPATHELPER_PRIV}}


### PR DESCRIPTION
@roland-KA 

After merging this you can follow the instructions for setting up the keys that are [here](https://juliaregistries.github.io/CompatHelper.jl/dev/#Creating-SSH-Key). 

If you get stuck, I'm happy to do it. I've struggled with setting these up in the past. Just thought you might want to learn how to do this for future projects...

