### PR TITLE
Add labels to connector lines

### DIFF
--- a/examples/DecisionTree_iris.jl
+++ b/examples/DecisionTree_iris.jl
@@ -6,6 +6,7 @@ in order to get a visually pleasing plot of the resulting decision tree.
 using DecisionTree      
 using Plots  
 using TreeRecipe
+import AbstractTrees
 
 # load and prepare the Iris data set
 features, labels = load_data("iris") 
@@ -27,4 +28,12 @@ wt = DecisionTree.wrap(dtree, (featurenames = feature_names,))
 # plot the decision tree (implicitly calling the `TreeRecipe` plot recipe)
 # `width` and `height` of the node rectangles as well as the `size` of the 
 # plotting area are adapted in order to get a visually pleasing output
-plot(wt, 0.8, 0.7; size = (1400,600))
+p1 = plot(wt, 0.8, 0.7; size = (1400,600))
+
+# plot the same tree with labels on the connector lines
+num_lines = AbstractTrees.treesize(wt) - 1    # the tree has #nodes - 1 connector lines
+p2 = plot(wt, 0.8, 0.7; size = (1400,600), connector_labels = repeat(["yes", "no"], num_lines ÷ 2))
+
+# show both plots
+display(p1)
+display(p2)

--- a/examples/DecisionTree_iris.jl
+++ b/examples/DecisionTree_iris.jl
@@ -30,9 +30,8 @@ wt = DecisionTree.wrap(dtree, (featurenames = feature_names,))
 # plotting area are adapted in order to get a visually pleasing output
 p1 = plot(wt, 0.8, 0.7; size = (1400,600))
 
-# plot the same tree with labels on the connector lines
-num_lines = AbstractTrees.treesize(wt) - 1    # the tree has #nodes - 1 connector lines
-p2 = plot(wt, 0.8, 0.7; size = (1400,600), connector_labels = repeat(["yes", "no"], num_lines ÷ 2))
+# plot the same tree with labels on the connecting lines
+p2 = plot(wt, 0.8, 0.7; size = (1400,600), connect_labels = ["yes", "no"])
 
 # show both plots
 display(p1)

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 BetaML = "024491cd-cc6b-443e-8034-08ea7eb7db2b"
 DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"


### PR DESCRIPTION
This is the implementation of an additional `connector_labels`-parameter which allows arbitrary labels on the connector lines of the tree as discussed in #7 .

@ablaom , @sylvaticus: Would this be a suitable solution to what we discussed in #7?